### PR TITLE
Send Seq API key via X-Seq-ApiKey header only, not query string

### DIFF
--- a/src/seq-server.ts
+++ b/src/seq-server.ts
@@ -45,10 +45,6 @@ const server = new McpServer({
 async function makeSeqRequest<T>(endpoint: string, params: Record<string, string> = {}): Promise<T> {
   const url = new URL(`${SEQ_BASE_URL}${endpoint}`);
 
-  if (SEQ_API_KEY) {
-    url.searchParams.append('apiKey', SEQ_API_KEY);
-  }
-
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined && value !== null) {
       url.searchParams.append(key, value);

--- a/src/seq-test.ts
+++ b/src/seq-test.ts
@@ -5,10 +5,7 @@ const SEQ_API_KEY = process.env.SEQ_API_KEY || '';
 
 async function makeSeqRequest<T>(endpoint: string, params: Record<string, string> = {}): Promise<T> {
   const url = new URL(`${SEQ_BASE_URL}${endpoint}`);
-  
-  // Add API key as query parameter
-  url.searchParams.append('apiKey', SEQ_API_KEY);
-  
+
   // Add additional query parameters
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined && value !== null) {


### PR DESCRIPTION
Send the Seq API key via the `X-Seq-ApiKey` header only, not the `?apiKey=` query string.

Today the client attaches the API key both as a request header and as a URL query parameter. Seq accepts either, so the query parameter is redundant — and it actively prevents the server from running behind a credential-injecting forward proxy. Sandboxed agent runtimes (e.g. Docker Sandboxes) keep secrets out of the workload by giving it a placeholder value and having the host-side proxy swap in the real credential on outbound requests. That rewrite happens on headers, which proxies can inspect and modify, but not on query strings inside an otherwise-opaque request. With the key in the URL, the placeholder leaks straight through to Seq and authentication fails. Dropping the query parameter and relying solely on `X-Seq-ApiKey` makes the server compatible with this secret-injection pattern, so the real key never has to enter the sandbox.

It's also a general hygiene win: secrets in URLs tend to leak into access logs, proxy logs, browser history, and Seq's own request/event logging, whereas header credentials don't.

No functional change for direct (non-proxied) users, since the header alone already authenticates.

## Changes
- `src/seq-server.ts` — remove the `apiKey` query-string append in `makeSeqRequest`; auth now via `X-Seq-ApiKey` header only.
- `src/seq-test.ts` — same removal in the integration test script.

## Testing
- `npm run build` passes.
- `npm run test-script` against a live Seq instance passes all four checks (51 signals, events via range, events via explicit date range, events filtered by signals) — confirming header-only auth works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)